### PR TITLE
feat: add the `hb.docs.navs_reduce_font_size` parameter, default to `true`

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -14,6 +14,7 @@ cache_key = "page.Type"
 
 [params.hb.docs]
 date_format = ":date_long"
+navs_reduce_font_size = false
 
 # Takes the full width by default.
 [params.hb.full_width_types.docs]

--- a/layouts/partials/hb/modules/docs/nav.html
+++ b/layouts/partials/hb/modules/docs/nav.html
@@ -28,6 +28,7 @@
 {{- define "walk-docs-tree" }}
   {{- $page := .Page }}
   {{- $border := default true site.Params.hb.docs.navs_border }}
+  {{- $reduceFontSize := default true site.Params.hb.docs.navs_reduce_font_size }}
   {{- range .Tree }}
     {{- $node := . }}
     {{- if $node.Page.IsSection }}
@@ -65,7 +66,7 @@
         </div>
         {{- with .Children }}
           <ul
-            class="collapse list-unstyled fw-normal small {{ cond $border `ms-1 ps-1 border-start` `ms-2` }}"
+            class="collapse list-unstyled fw-normal {{ cond $reduceFontSize `small` `` }} {{ cond $border `ms-1 ps-1 border-start` `ms-2` }}"
             id="{{ $collapseId }}">
             {{- template "walk-docs-tree" (dict "Tree" . "Page" $page) }}
             {{- with $node.Page.Params.nav_menus }}


### PR DESCRIPTION
Do not reduce submenus font size if `false`