### PR TITLE
feat: add the `docs_root_section` page parameter

### DIFF
--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,7 +1,8 @@
 {{- define "main" }}
   <div class="hb-docs">
     <div class="hb-docs-sidebar" tabindex="-1" data-bs-hide="focusout">
-      {{ partialCached "hb/modules/docs/nav" . .FirstSection }}
+      {{ $rootSection := partialCached "hb/modules/docs/functions/root-section" . . }}
+      {{ partialCached "hb/modules/docs/nav" . $rootSection }}
     </div>
     <div class="hb-docs-main col-12 col-xxl-10">
       {{ partial "hugopress/functions/render-hooks" (dict "Page" . "Name" "hb-docs-main-begin") }}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,7 +1,8 @@
 {{- define "main" }}
   <div class="hb-docs">
     <div class="hb-docs-sidebar" tabindex="-1" data-bs-hide="focusout">
-      {{ partialCached "hb/modules/docs/nav" . .FirstSection }}
+      {{ $rootSection := partialCached "hb/modules/docs/functions/root-section" . . }}
+      {{ partialCached "hb/modules/docs/nav" . $rootSection }}
     </div>
     <div class="hb-docs-main">
       {{ partial "hugopress/functions/render-hooks" (dict "Page" . "Name" "hb-docs-main-begin") }}

--- a/layouts/partials/hb/modules/docs/functions/root-section.html
+++ b/layouts/partials/hb/modules/docs/functions/root-section.html
@@ -1,0 +1,11 @@
+{{- $section := .FirstSection }}
+{{- if not (default true $section.Params.docs_root_section) }}
+  {{- with index .Ancestors.Reverse 2 }}
+    {{- $section = . }}
+  {{- else }}
+    {{- if .IsSection }}
+      {{- $section = . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- return $section }}

--- a/layouts/partials/hb/modules/docs/functions/tree.html
+++ b/layouts/partials/hb/modules/docs/functions/tree.html
@@ -1,3 +1,3 @@
-{{/* Returns the pages tree of first section of current page. */}}
-{{- $tree := partial "hb/modules/docs/functions/walk-section" .FirstSection }}
+{{/* Returns the pages tree of the root section of current page. */}}
+{{- $tree := partial "hb/modules/docs/functions/walk-section" . }}
 {{- return $tree -}}

--- a/layouts/partials/hb/modules/docs/nav.html
+++ b/layouts/partials/hb/modules/docs/nav.html
@@ -1,4 +1,5 @@
-{{- $tree := partialCached "hb/modules/docs/functions/tree" . .FirstSection }}
+{{- $rootSection := partialCached "hb/modules/docs/functions/root-section" . . }}
+{{- $tree := partialCached "hb/modules/docs/functions/tree" $rootSection $rootSection }}
 <div
   class="hb-docs-nav offcanvas-lg pe-lg-2 offcanvas-start"
   aria-labelledby="hb-docs-nav-label">


### PR DESCRIPTION
When the `docs_root_section` is set as `false` on first section, then the second section will be used as the root section for navigation on left sidebar

Closes #860